### PR TITLE
chore: standardize on pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 !.yarn/releases
 !.yarn/versions
 
+# lock files for other package managers
+package-lock.json
+yarn.lock
+
 # testing
 /coverage
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,11 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+Install dependencies and start the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.20.4",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@10.13.1"
 }


### PR DESCRIPTION
## Summary
- remove npm lock file and ignore non-pnpm locks
- document pnpm usage and pin package manager

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfff3fcfbc8332b3929f3e232c2415