### PR TITLE
Handle unhandled Stripe webhook events gracefully

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -11,37 +11,43 @@ export const POST = async (req: NextRequest) => {
 
   if (event.type === "charge.succeeded") {
     const charge = event.data.object as Stripe.Charge;
-    const orderId = charge.metadata.orderId;
+    const orderId = charge.metadata?.orderId;
 
-    if (orderId) {
-      try {
-        const updatedOrder = await updateOrderToPaid({
-          orderId,
-          paymentResult: {
-            id: charge.id,
-            status: "COMPLETED",
-            pricePaid: parseFloat((charge.amount / 100).toFixed(2)),
-            email_address: charge.receipt_email || "",
-          },
-        });
-        console.log("Order updated to paid:", updatedOrder);
-        return NextResponse.json({
-          success: true,
-          message: "Order updated successfully",
-        });
-      } catch (error) {
-        console.error("Failed to update order to paid:", error);
-        return NextResponse.json(
-          { success: false, message: "Failed to update order" },
-          { status: 500 }
-        );
-      }
+    if (!orderId) {
+      console.error("No orderId in charge metadata");
+      return NextResponse.json({
+        success: false,
+        message: "No orderId in charge metadata",
+      });
+    }
+
+    try {
+      const updatedOrder = await updateOrderToPaid({
+        orderId,
+        paymentResult: {
+          id: charge.id,
+          status: "COMPLETED",
+          pricePaid: parseFloat((charge.amount / 100).toFixed(2)),
+          email_address: charge.receipt_email || "",
+        },
+      });
+      console.log("Order updated to paid:", updatedOrder);
+      return NextResponse.json({
+        success: true,
+        message: "Order updated successfully",
+      });
+    } catch (error) {
+      console.error("Failed to update order to paid:", error);
+      return NextResponse.json(
+        { success: false, message: "Failed to update order" },
+        { status: 500 }
+      );
     }
   }
 
-  console.error("No orderId in charge metadata");
-  return NextResponse.json(
-    { success: false, message: "No orderId in charge metadata" },
-    { status: 400 }
-  );
+  console.log(`Unhandled Stripe event received: ${event.type}`);
+  return NextResponse.json({
+    success: true,
+    message: `Unhandled event type: ${event.type}`,
+  });
 };


### PR DESCRIPTION
## Summary
- ensure the Stripe webhook acknowledges charge events without order metadata using a 2xx response
- add logging and a success response for unhandled Stripe event types to prevent retries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba47c88888332a3acee8c0917d991